### PR TITLE
sv_timestamp_analysis: fix wrong use of args for subscriber name

### DIFF
--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -329,9 +329,9 @@ if __name__ == "__main__":
     else:
         hyp_name=args.hypervisor_name
     if not args.subscriber_name:
-        sub_name=args.hyp
+        sub_name=args.sub
     else:
-        sub_name=args.hypervisor_name
+        sub_name=args.subscriber_name
 
     generate_adoc(
         args.pub,


### PR DESCRIPTION
Hypervisors arguments were used for the subscriber name instead of subscriber arguments.