### PR TITLE
Refactor analysis processing to reduce script memory footprint

### DIFF
--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -18,12 +18,18 @@ class SvExtractor:
         self.sv_file_path = sv_file_path
 
     def __enter__(self):
-        self.sv_file = open(self.sv_file_path, "r", encoding="utf-8")
-        self._last_line = self.sv_file.readline() 
+        if self.sv_file_path is not None:
+            self.sv_file = open(self.sv_file_path, "r", encoding="utf-8")
+            self._last_line = self.sv_file.readline()
+        else:
+            self.sv_file = None
+
         return self
 
     def __exit__(self, exc_type, exc, tb):
-        self.sv_file.close()
+        if self.sv_file is not None:
+            self.sv_file.close()
+
         return False
 
     def extract_sv(self, streams, nb_iterations=0):
@@ -47,6 +53,9 @@ class SvExtractor:
 
         if not streams:
             raise ValueError("Invalid or empty list of streams found, the -S argument might be incorrect")
+
+        if self.sv_file is None:
+            raise ValueError("No SV file opened, cannot extract SV data")
 
         sv_content = []
         stop_parsing = False
@@ -352,19 +361,37 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
         total_sv_drop = 0
         sub_pacing_df = [ pd.DataFrame({"pacing": [], "count": []}) for _ in range(len(streams)) ]
 
-        with SvExtractor(pub) as pub_extractor, SvExtractor(sub) as sub_extractor:
+        if hyp is not None:
+            verify_sv_logs_consistency(pub, hyp)
+            hyp_latencies_df = [ pd.DataFrame({"latency": [], "count": []}) for _ in range(len(streams)) ] 
+            hyp_total_sv_drop = 0
+            hyp_pacing_df = [ pd.DataFrame({"pacing": [], "count": []}) for _ in range(len(streams)) ]
+
+
+        with SvExtractor(pub) as pub_extractor, SvExtractor(sub) as sub_extractor, SvExtractor(hyp) as hyp_extractor:
             chunk_size = 100
             last_sub_sv = None
+            last_hyp_sv = None
 
             pub_sv, _ = pub_extractor.extract_sv(streams, chunk_size)
             sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, chunk_size)
+            if hyp is not None:
+                hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams, chunk_size)
+
 
             while len(sub_stream_names) > 0:
                 # Latencies
                 chunk_latencies, sv_drop = compute_latency(pub_sv, sub_sv)
                 total_sv_drop += sv_drop
+                if hyp is not None:
+                    chunk_hyp_latencies, hyp_sv_drop = compute_latency(pub_sv, hyp_sv)
+                    hyp_total_sv_drop += hyp_sv_drop
+
                 for i in range(len(streams)):
                     latencies_df[i] = add_counts_to_df(latencies_df[i], chunk_latencies[i])
+                    if hyp is not None:
+                        hyp_latencies_df[i] = add_counts_to_df(hyp_latencies_df[i], chunk_hyp_latencies[i])
+
 
                 # Pacing
                 if last_sub_sv is not None:
@@ -377,9 +404,23 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
 
                 last_sub_sv = [s[2][-1] for s in sub_sv]
 
+                if hyp is not None:
+                    if last_hyp_sv is not None:
+                        chunk_hyp_pacing = compute_pacing(hyp_sv, prepend=last_hyp_sv)
+                    else:
+                        chunk_hyp_pacing = compute_pacing(hyp_sv)
+
+                    for i in range(len(streams)):
+                        hyp_pacing_df[i] = add_counts_to_df(hyp_pacing_df[i], chunk_hyp_pacing[i])
+
+                    last_hyp_sv = [s[2][-1] for s in hyp_sv]
+
+
                 # Next chunk
                 pub_sv, _ = pub_extractor.extract_sv(streams, chunk_size)
                 sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, chunk_size)
+                if hyp is not None:
+                    hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams, chunk_size)
 
         for i in range(len(streams)):
             if display_threshold:
@@ -405,15 +446,6 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
         )
 
         if hyp is not None:
-            verify_sv_logs_consistency(pub, hyp)
-
-            hyp_sv = []
-            hyp_stream_names = []
-            with SvExtractor(hyp) as hyp_extractor:
-                hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams)
-
-            hyp_latencies, total_sv_drop = compute_latency(pub_sv, hyp_sv)
-            hyp_pace = compute_pacing(hyp_sv)
             adoc_file.write(
                     hypervisor_lines.format(
                         _output_=output,

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -195,25 +195,37 @@ def compute_average(values):
 def compute_neglat(values):
     return np.count_nonzero(values < 0)
 
-def save_latency_histogram(values, streams, sub_name, output, threshold=0):
+def save_latency_histogram(df, stream, sub_name, output, threshold=0):
+    """Save a latency histogram for an SV stream from a latency dataframe.
 
-    for stream, value in zip(streams, values):
-        plt.hist(value, bins=20, alpha=0.7)
+    Args:
+        df (DataFrame): Latency dataframe.
+        stream (int): SV stream ID.
+        sub_name (str): Subscriber name.
+        output (str): Output path where the histogram will be saved in a "results" subdirectory.
+        threshold (int, optional): Threshold value that will be represented as a vertical red line.
+            If <= 0, this threshold isn't showed. Defaults to 0.
 
-        plt.xlabel(f"Latency (us)")
-        plt.ylabel("Occurrences")
-        plt.yscale('log')
-        plt.title(f"{sub_name} SV stream 0x{stream:04x} latency histogram")
+    Returns:
+        str: Full file path of the save histogram.
+    """
 
-        if threshold > 0:
-            plt.axvline(x=threshold, color='red', linestyle='dashed', linewidth=2, label=f'Limit ({threshold} us)')
-            plt.legend()
+    plt.hist(df["latency"], bins=20, weights=df["count"], alpha=0.7)
 
-        filename = f"histogram_{sub_name}_stream_{stream}_latency.png"
-        filepath = os.path.realpath(f"{output}/results/{filename}")
-        plt.savefig(filepath)
-        print(f"Histogram saved as {filename}.")
-        plt.close()
+    plt.xlabel("Latency (us)")
+    plt.ylabel("Occurrences")
+    plt.yscale("log")
+    plt.title(f"{sub_name} SV stream 0x{stream:04x} latency histogram")
+
+    if threshold > 0:
+        plt.axvline(x=threshold, color='red', linestyle='dashed', linewidth=2, label=f'Limit ({threshold} us)')
+        plt.legend()
+
+    filename = f"histogram_{sub_name}_stream_{stream}_latency.png"
+    filepath = os.path.realpath(f"{output}/results/{filename}")
+    plt.savefig(filepath)
+    print(f"Histogram saved as {filename}.")
+    plt.close()
 
     return filepath
 
@@ -286,10 +298,18 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
 
         latencies, total_sv_drop = compute_latency(pub_sv, sub_sv)
         sub_pacing = compute_pacing(sub_sv)
-        if display_threshold:
-            save_latency_histogram(latencies, streams, sub_name, output, max_latency_threshold)
-        else:
-            save_latency_histogram(latencies, streams, sub_name, output)
+
+        latencies_df = []
+        for i in range(len(streams)):
+            val, counts = np.unique(latencies[i], return_counts=True)
+            latencies_df.append(pd.DataFrame({"latency": val, "count": counts}))
+
+        for i in range(len(streams)):
+            if display_threshold:
+                save_latency_histogram(latencies_df[i], streams[i], sub_name, output, max_latency_threshold)
+            else:
+                save_latency_histogram(latencies_df[i], streams[i], sub_name, output)
+
         maxlat= compute_max(latencies[0])
         minlat = compute_min(latencies[0])
         adoc_file.write(

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -4,6 +4,7 @@
 
 import os
 import argparse
+import subprocess
 import matplotlib.pyplot as plt
 import textwrap
 import numpy as np
@@ -89,21 +90,50 @@ class SvExtractor:
         return sv, stream_names
 
 
-def verify_sv_logs_consistency(sv_data_1, sv_data_2, sv_filename_1, sv_filename_2):
-# Verify that both sv files are comparables. It means that they contain the same number of iterations.
-# If they do not have the same number of iterations, it can mean :
-# - packets reordering
-# - too many SV lost.
-# In that case, the latency cannot be computed, because a received SV cannot
-# be linked correctly to a published SV.
+def verify_sv_logs_consistency(sv_filename_1, sv_filename_2):
+    """Verify that both SV files are comparables. It means that they contain the same number of iterations.
 
-    # Check last iteration counter
-    for stream in range(0, len(sv_data_1)):
-        # Compare last value of the iteration columns
-        if sv_data_1[stream][0][-1] != sv_data_2[stream][0][-1]:
-            raise ValueError(
-                f"{sv_filename_1} and {sv_filename_2} don't have the same number of iterations"
-            )
+    If they do not have the same number of iterations, it can mean:
+    * Packets were re-ordered.
+    * Too many SV were lost.
+    In that case, latencies cannot be computed, because some received SV cannot
+    be linked correctly to a published SV.
+
+    Raises:
+        ValueError: If the two SV files do not have the same number of iterations.
+        CalledProcessError: If the "tail" command failed.
+
+    Returns:
+        None
+    """
+
+    tail_1 = subprocess.run(
+        ["tail", "-n", "1", sv_filename_1],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    tail_2 = subprocess.run(
+        ["tail", "-n", "1", sv_filename_2],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    last_it_1 = tail_1.stdout.rstrip().split(":")[0]
+    last_it_2 = tail_2.stdout.rstrip().split(":")[0]
+
+    if not last_it_1:
+        raise ValueError(f"{sv_filename_1} has no valid data.")
+    if not last_it_2:
+        raise ValueError(f"{sv_filename_2} has no valid data.")
+
+    if last_it_1 != last_it_2:
+        raise ValueError(
+            f"{sv_filename_1} has {last_it_1} iterations but {sv_filename_2} has {last_it_2}"
+        )
 
 
 def handle_sv_drop(pub_stream, sub_stream):
@@ -252,7 +282,7 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
             pub_sv, _ = pub_extractor.extract_sv(streams)
             sub_sv, sub_stream_names = sub_extractor.extract_sv(streams)
 
-        verify_sv_logs_consistency(pub_sv, sub_sv, pub, sub)
+        verify_sv_logs_consistency(pub, sub)
 
         latencies, total_sv_drop = compute_latency(pub_sv, sub_sv)
         sub_pacing = compute_pacing(sub_sv)
@@ -283,7 +313,7 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
             with SvExtractor(hyp) as hyp_extractor:
                 hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams)
 
-            verify_sv_logs_consistency(pub_sv, hyp_sv, pub, hyp)
+            verify_sv_logs_consistency(pub, hyp)
             hyp_latencies, total_sv_drop = compute_latency(pub_sv, hyp_sv)
             hyp_pace = compute_pacing(hyp_sv)
             adoc_file.write(

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -163,25 +163,39 @@ def handle_sv_drop(pub_stream, sub_stream):
 
 
 def compute_latency(pub_sv, sub_sv):
+    """Compute latencies between publisher SV timestamps and subscriber SV timestamps.
 
-    latencies = [[]] * len(pub_sv)
+    Args:
+        pub_sv (list): SV data for the publisher side as extracted by SvExtractor.extract_sv().
+            Should be the same length as "sub_sv.
+        sub_sv (list): SV data for the subscriber side as extracted by SvExtractor.extract_sv().
+            Should be the same length as "pub_sv.
+
+    Raises:
+        ValueError: If "pub_sv" and "sub_sv" do not have the same length.
+
+    Returns:
+        (list, int): Tuple containing:
+            * A list of numpy arrays with latency values per stream.
+            * The total number of SV that were dropped (i.e. that couldn't be linked to a published SV).
+                This number is global to all streams.
+    """
+
+    latencies = [[] for _ in range(len(pub_sv))]
     sv_drop = 0
 
-    for stream in range(0, len(pub_sv)):
-
-        pub_sv_stream = pub_sv[stream]
-        sub_sv_stream = sub_sv[stream]
+    for (pub_sv_stream, sub_sv_stream, latencies_stream) in zip(pub_sv, sub_sv, latencies, strict=True):
         sv_drop_stream = abs(len(pub_sv_stream[0]) - len(sub_sv_stream[0]))
         sv_drop += sv_drop_stream
 
         if sv_drop_stream > 0:
-            # if sv drop is detected on this stream, pandas will be used to
-            # reconstruct the link between data and compute the latency
-            # It will take additionnal times to convert from numpy to pandas,
+            # If sv drop is detected on this stream, pandas will be used to
+            # reconstruct the link between data and compute the latency.
+            # It will take additional time to convert from numpy to pandas,
             # so this is only done when there is sv drop.
-            latencies[stream] = handle_sv_drop(pub_sv_stream, sub_sv_stream)
+            latencies_stream[:] = handle_sv_drop(pub_sv_stream, sub_sv_stream)
         else:
-            latencies[stream] = sub_sv_stream[2] - pub_sv_stream[2]
+            latencies_stream[:] = sub_sv_stream[2] - pub_sv_stream[2]
 
     return latencies, sv_drop
 

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -321,7 +321,7 @@ def save_latency_histogram(df, stream, sub_name, output, threshold=0):
 
     return filepath
 
-def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latency_threshold, display_threshold):
+def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latency_threshold, display_threshold, processing_window=100):
     if not os.path.exists(f'{output}/results'):
         os.makedirs(f'{output}/results')
 
@@ -393,14 +393,13 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
 
 
         with SvExtractor(pub) as pub_extractor, SvExtractor(sub) as sub_extractor, SvExtractor(hyp) as hyp_extractor:
-            chunk_size = 100
             last_sub_sv = None
             last_hyp_sv = None
 
-            pub_sv, _ = pub_extractor.extract_sv(streams, chunk_size)
-            sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, chunk_size)
+            pub_sv, _ = pub_extractor.extract_sv(streams, processing_window)
+            sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, processing_window)
             if hyp is not None:
-                hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams, chunk_size)
+                hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams, processing_window)
 
 
             while len(sub_stream_names) > 0:
@@ -441,10 +440,10 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
 
 
                 # Next chunk
-                pub_sv, _ = pub_extractor.extract_sv(streams, chunk_size)
-                sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, chunk_size)
+                pub_sv, _ = pub_extractor.extract_sv(streams, processing_window)
+                sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, processing_window)
                 if hyp is not None:
-                    hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams, chunk_size)
+                    hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams, processing_window)
 
         for i in range(len(streams)):
             if display_threshold:
@@ -589,6 +588,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Display max latency threshold on histograms if set"
     )
+    parser.add_argument(
+        "--processing_window",
+        default=100,
+        type=int,
+        help="Number of SV iteration to process at once. Decreasing this value reduces memory usage."
+    )
 
     args = parser.parse_args()
     if not args.hypervisor_name:
@@ -610,4 +615,5 @@ if __name__ == "__main__":
         args.output,
         args.max_latency,
         args.display_max_latency,
+        args.processing_window,
     )

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -215,6 +215,45 @@ def compute_average(values):
 def compute_neglat(values):
     return np.count_nonzero(values < 0)
 
+def add_counts_to_df(df, values):
+    """Count occurrences of each unique integer values in "values" and add them to a dataframe holding counts.
+
+    Args:
+        df (DataFrame): DataFrame holding initial counts of values.
+            It should have 2 columns:
+            * One "count" column where counts from "values" will be added.
+            * One column which holds the values corresponding to the counts.
+        values (array-like): Numpy array or list of integer values to count and add to the DataFrame.
+
+    Raises
+        ValueError: If "df" doesn't have exactly 2 columns, with one labeled "count".
+
+    Returns:
+        DataFrame: DataFrame with counts from "values" added to "df" counts.
+    """
+
+    if len(df.columns) != 2:
+        raise ValueError("DataFrame doesn't have exactly 2 columns")
+    if "count" not in df.columns:
+        raise ValueError("DataFrame doesn't have a 'count' column")
+    
+    vals, counts = np.unique(values, return_counts=True)
+
+    vals_columns = df.columns.drop("count")[0]
+    counts_df = pd.DataFrame({vals_columns: vals, "count": counts})
+
+    df = pd.merge(df, counts_df, on=vals_columns, how="outer", suffixes=("", "_add"))
+
+    # Outer merge introduces NaN when a latency doesn't exist in one of the two tables
+    df = df.fillna(0)
+
+    df["count"] += df.pop("count_add")
+
+    # Introduction of NaN values in merge changed data type to float64
+    df = df.astype(np.int64)
+
+    return df
+
 def save_latency_histogram(df, stream, sub_name, output, threshold=0):
     """Save a latency histogram for an SV stream from a latency dataframe.
 
@@ -321,21 +360,11 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
             sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, chunk_size)
 
             while len(sub_stream_names) > 0:
+                # Latencies
                 chunk_latencies, sv_drop = compute_latency(pub_sv, sub_sv)
-
                 total_sv_drop += sv_drop
-
                 for i in range(len(streams)):
-                    val, counts = np.unique(chunk_latencies[i], return_counts=True)
-                    df = pd.DataFrame({"latency": val, "count": counts})
-
-                    # Merge chunk latencies with global counts
-                    latencies_df[i] = pd.merge(latencies_df[i], df, on="latency", how="outer", suffixes=("", "_chunk"))
-                    latencies_df[i] = latencies_df[i].fillna(0) # Outer merge introduces NaN when a latency doesn't exist in one of the two tables
-                    latencies_df[i]["count"] += latencies_df[i].pop("count_chunk")
-
-                    # Introduction of NaN values in merge changed data type to float64
-                    latencies_df[i] = latencies_df[i].astype(np.int64)
+                    latencies_df[i] = add_counts_to_df(latencies_df[i], chunk_latencies[i])
 
                 # Pacing
                 if last_sub_sv is not None:
@@ -344,16 +373,7 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
                     chunk_sub_pacing = compute_pacing(sub_sv)
 
                 for i in range(len(streams)):
-                    val, counts = np.unique(chunk_sub_pacing[i], return_counts=True)
-                    df = pd.DataFrame({"pacing": val, "count": counts})
-
-                    # Merge chunk pacing with global counts
-                    sub_pacing_df[i] = pd.merge(sub_pacing_df[i], df, on="pacing", how="outer", suffixes=("", "_chunk"))
-                    sub_pacing_df[i] = sub_pacing_df[i].fillna(0) # Outer merge introduces NaN when a latency doesn't exist in one of the two tables
-                    sub_pacing_df[i]["count"] += sub_pacing_df[i].pop("count_chunk")
-
-                    # Introduction of NaN values in merge changed data type to float64
-                    sub_pacing_df[i] = sub_pacing_df[i].astype(np.int64)
+                    sub_pacing_df[i] = add_counts_to_df(sub_pacing_df[i], chunk_sub_pacing[i])
 
                 last_sub_sv = [s[2][-1] for s in sub_sv]
 

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -176,11 +176,31 @@ def compute_latency(pub_sv, sub_sv):
 
     return latencies, sv_drop
 
-def compute_pacing(sv):
-    streams = len(sv)
+def compute_pacing(sv, prepend=None):
+    """Compute the pacing of some SV data.
+
+    Args:
+        sv (list): SV data as extracted by SvExtractor.extract_sv().
+            List of N numpy arrays of shape (3, M) where:
+            * N is the number of SV streams.
+            * M is the number of SV for the stream.
+        prepend (int, list, optional): List of N values to prepend to sv before computing the pacing.
+            This is passed to np.diff() "prepend" argument.
+            This is typically useful when processing data in chunks, and that the last value of
+            the previous chunk is needed to compute the pacing of the first value of the current chunk.
+            Defaults to None.
+
+    Returns:
+        list: List of N numpy arrays with pacing values.
+    """
+
     pacing = [[0]] * len(sv)
-    for stream in range(0, streams):
-        pacing[stream] = np.diff(sv[stream][2])
+    for i in range(len(sv)):
+        if prepend is not None:
+            pacing[i] = np.diff(sv[i][2], prepend=prepend[i])
+        else:
+            pacing[i] = np.diff(sv[i][2])
+
     return pacing
 
 def compute_min(values):
@@ -291,9 +311,11 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
 
         latencies_df = [ pd.DataFrame({"latency": [], "count": []}) for _ in range(len(streams)) ]
         total_sv_drop = 0
+        sub_pacing_df = [ pd.DataFrame({"pacing": [], "count": []}) for _ in range(len(streams)) ]
 
         with SvExtractor(pub) as pub_extractor, SvExtractor(sub) as sub_extractor:
             chunk_size = 100
+            last_sub_sv = None
 
             pub_sv, _ = pub_extractor.extract_sv(streams, chunk_size)
             sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, chunk_size)
@@ -314,6 +336,26 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
 
                     # Introduction of NaN values in merge changed data type to float64
                     latencies_df[i] = latencies_df[i].astype(np.int64)
+
+                # Pacing
+                if last_sub_sv is not None:
+                    chunk_sub_pacing = compute_pacing(sub_sv, prepend=last_sub_sv)
+                else:
+                    chunk_sub_pacing = compute_pacing(sub_sv)
+
+                for i in range(len(streams)):
+                    val, counts = np.unique(chunk_sub_pacing[i], return_counts=True)
+                    df = pd.DataFrame({"pacing": val, "count": counts})
+
+                    # Merge chunk pacing with global counts
+                    sub_pacing_df[i] = pd.merge(sub_pacing_df[i], df, on="pacing", how="outer", suffixes=("", "_chunk"))
+                    sub_pacing_df[i] = sub_pacing_df[i].fillna(0) # Outer merge introduces NaN when a latency doesn't exist in one of the two tables
+                    sub_pacing_df[i]["count"] += sub_pacing_df[i].pop("count_chunk")
+
+                    # Introduction of NaN values in merge changed data type to float64
+                    sub_pacing_df[i] = sub_pacing_df[i].astype(np.int64)
+
+                last_sub_sv = [s[2][-1] for s in sub_sv]
 
                 # Next chunk
                 pub_sv, _ = pub_extractor.extract_sv(streams, chunk_size)

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -218,8 +218,8 @@ def compute_min(values):
 def compute_max(values):
     return np.max(values) if values.size > 0 else None
 
-def compute_average(values):
-    return np.round(np.mean(values)) if values.size > 0 else None
+def compute_average(values, weights=None):
+    return np.round(np.average(values, weights=weights)) if values.size > 0 else None
 
 def compute_neglat(values):
     return np.count_nonzero(values < 0)
@@ -428,20 +428,20 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
             else:
                 save_latency_histogram(latencies_df[i], streams[i], sub_name, output)
 
-        maxlat= compute_max(latencies[0])
-        minlat = compute_min(latencies[0])
+        maxlat= compute_max(latencies_df[0]["latency"])
+        minlat = compute_min(latencies_df[0]["latency"])
         adoc_file.write(
                 subcriber_lines.format(
                     _output_=output,
                     _subscriber_name_=sub_name,
-                    _stream_id_= sub_stream_names[0],
+                    _stream_id_= streams[0],
                     _stream_ = streams[0],
                     _minlat_= minlat,
                     _maxlat_= maxlat,
-                    _avglat_= compute_average(latencies[0]),
-                    _minpace_= compute_min(sub_pacing[0]),
-                    _maxpace_= compute_max(sub_pacing[0]),
-                    _avgpace_= compute_average(sub_pacing[0]),
+                    _avglat_= compute_average(latencies_df[0]["latency"], latencies_df[0]["count"]),
+                    _minpace_= compute_min(sub_pacing_df[0]["pacing"]),
+                    _maxpace_= compute_max(sub_pacing_df[0]["pacing"]),
+                    _avgpace_= compute_average(sub_pacing_df[0]["pacing"], sub_pacing_df[0]["count"]),
                 )
         )
 
@@ -450,14 +450,14 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
                     hypervisor_lines.format(
                         _output_=output,
                         _hypervisor_name_=hyp_name,
-                        _stream_id_= hyp_stream_names[0],
+                        _stream_id_= streams[0],
                         _stream_ = streams[0],
-                        _minlat_= compute_min(hyp_latencies[0]),
+                        _minlat_= compute_min(hyp_latencies_df[0]["latency"]),
                         _maxlat_= maxlat,
-                        _avglat_= compute_average(hyp_latencies[0]),
-                        _minpace_= compute_min(hyp_pace[0]),
-                        _maxpace_= compute_max(hyp_pace[0]),
-                        _avgpace_= compute_average(hyp_pace[0]),
+                        _avglat_= compute_average(hyp_latencies_df[0]["latency"], hyp_latencies_df[0]["count"]),
+                        _minpace_= compute_min(hyp_pacing_df[0]["pacing"]),
+                        _maxpace_= compute_max(hyp_pacing_df[0]["pacing"]),
+                        _avgpace_= compute_average(hyp_pacing_df[0]["pacing"], hyp_pacing_df[0]["count"]),
                     )
             )
 

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -146,11 +146,21 @@ def verify_sv_logs_consistency(sv_filename_1, sv_filename_2):
 
 
 def handle_sv_drop(pub_stream, sub_stream):
-    # Compute the latency on a stream with sv lost
-    # All the magic remains in the pandas dataframe merge function using the
-    # inner method to combine tables. This function handles the missalignement
-    # between subscriber and publisher values.
-    # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.merge.html
+    """Compute the latency on a stream with sv drops.
+
+    All the magic remains in the pandas.DataFrame.merge() method using the
+    inner method to combine tables. This function handles the misalignment
+    between subscriber and publisher values.
+
+    Args:
+        pub_stream (numpy-array): publisher SV data for one stream as extracted by SvExtractor.extract_sv().
+            Shape is (3, N), where N is the number of SV.
+        sub_stream (numpy-array): subscriber SV data for one stream as extracted by SvExtractor.extract_sv().
+            Shape is (3, N), where N is the number of SV.
+
+    Returns:
+        numpy-array: 1d numpy-array of length N with the computed latencies for the SV stream.
+    """
 
     columns = ["iteration", "counter", "time"]
     pub_data = pd.DataFrame(pub_stream, index=columns).T

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -289,20 +289,35 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
 
         verify_sv_logs_consistency(pub, sub)
 
-        pub_sv = []
-        sub_sv = []
-        sub_stream_names = []
+        latencies_df = [ pd.DataFrame({"latency": [], "count": []}) for _ in range(len(streams)) ]
+        total_sv_drop = 0
+
         with SvExtractor(pub) as pub_extractor, SvExtractor(sub) as sub_extractor:
-            pub_sv, _ = pub_extractor.extract_sv(streams)
-            sub_sv, sub_stream_names = sub_extractor.extract_sv(streams)
+            chunk_size = 100
 
-        latencies, total_sv_drop = compute_latency(pub_sv, sub_sv)
-        sub_pacing = compute_pacing(sub_sv)
+            pub_sv, _ = pub_extractor.extract_sv(streams, chunk_size)
+            sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, chunk_size)
 
-        latencies_df = []
-        for i in range(len(streams)):
-            val, counts = np.unique(latencies[i], return_counts=True)
-            latencies_df.append(pd.DataFrame({"latency": val, "count": counts}))
+            while len(sub_stream_names) > 0:
+                chunk_latencies, sv_drop = compute_latency(pub_sv, sub_sv)
+
+                total_sv_drop += sv_drop
+
+                for i in range(len(streams)):
+                    val, counts = np.unique(chunk_latencies[i], return_counts=True)
+                    df = pd.DataFrame({"latency": val, "count": counts})
+
+                    # Merge chunk latencies with global counts
+                    latencies_df[i] = pd.merge(latencies_df[i], df, on="latency", how="outer", suffixes=("", "_chunk"))
+                    latencies_df[i] = latencies_df[i].fillna(0) # Outer merge introduces NaN when a latency doesn't exist in one of the two tables
+                    latencies_df[i]["count"] += latencies_df[i].pop("count_chunk")
+
+                    # Introduction of NaN values in merge changed data type to float64
+                    latencies_df[i] = latencies_df[i].astype(np.int64)
+
+                # Next chunk
+                pub_sv, _ = pub_extractor.extract_sv(streams, chunk_size)
+                sub_sv, sub_stream_names = sub_extractor.extract_sv(streams, chunk_size)
 
         for i in range(len(streams)):
             if display_threshold:

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -12,6 +12,83 @@ import pandas as pd
 GREEN_COLOR = "#90EE90"
 RED_COLOR = "#F08080"
 
+class SvExtractor:
+    def __init__(self, sv_file_path):
+        self.sv_file_path = sv_file_path
+
+    def __enter__(self):
+        self.sv_file = open(self.sv_file_path, "r", encoding="utf-8")
+        self._last_line = self.sv_file.readline() 
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.sv_file.close()
+        return False
+
+    def extract_sv(self, streams, nb_iterations=0):
+        """Extract a given number of SV timestamp data iterations from the SV data file.
+
+        Args:
+            streams (list): of stream IDs to extract
+            nb_iterations (int, optional): Number of SV iterations to extract.
+                Defaults to 0 which means to extract until the end of the file.
+
+        Returns:
+            A tuple containing:
+            * A list of numpy arrays with extracted SV data per given stream.
+              Index 0 has data for the first given stream, index 1 for the second, etc...
+              For each stream, the data is as follows:
+                * Index 0: numpy array of iteration number for each SV.
+                * Index 1: numpy array of smpCnt for each SV.
+                * Index 2: numpy array of timestamp for each SV.
+            * The stream IDs found in the file. Might differ from the given streams.
+        """
+
+        if not streams:
+            raise ValueError("Invalid or empty list of streams found, the -S argument might be incorrect")
+
+        sv_content = []
+        stop_parsing = False
+        stop_iteration = 0
+
+        def parse(line):
+            tmp = line.rstrip().split(':')
+            return (int(tmp[0]), str(tmp[1]), int(tmp[2]), int(tmp[3]))
+
+        if self._last_line:
+            sv_content.append(parse(self._last_line))
+            if nb_iterations > 0:
+                stop_iteration = sv_content[0][0] + nb_iterations
+        else:
+            # EOF was already reached, nothing should be parsed
+            stop_parsing = True
+
+        while not stop_parsing:
+            line = self.sv_file.readline()
+            if line:
+                sv = parse(line)
+                if stop_iteration == 0 or sv[0] < stop_iteration:
+                    sv_content.append(sv)
+                    continue
+
+            # EOF or stop_iteration reached
+            self._last_line = line
+            stop_parsing = True
+
+        sv_it = np.array([i[0] for i in sv_content])
+        sv_id = np.array([i[1] for i in sv_content])
+        sv_cnt = np.array([i[2] for i in sv_content])
+        sv_timestamps = np.array([i[3] for i in sv_content])
+
+        stream_names = np.unique(sv_id)
+        sv = []
+        for s in streams:
+            ids_occur = np.where(sv_id == f"{s:04x}")
+            sv.append([sv_it[ids_occur], sv_cnt[ids_occur], sv_timestamps[ids_occur]])
+
+        return sv, stream_names
+
+
 def extract_sv(sv_file_path, streams):
     stream_number = 0
     with open(f"{sv_file_path}", "r", encoding="utf-8") as sv_file:

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -275,14 +275,14 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
             """
         )
 
+        verify_sv_logs_consistency(pub, sub)
+
         pub_sv = []
         sub_sv = []
         sub_stream_names = []
         with SvExtractor(pub) as pub_extractor, SvExtractor(sub) as sub_extractor:
             pub_sv, _ = pub_extractor.extract_sv(streams)
             sub_sv, sub_stream_names = sub_extractor.extract_sv(streams)
-
-        verify_sv_logs_consistency(pub, sub)
 
         latencies, total_sv_drop = compute_latency(pub_sv, sub_sv)
         sub_pacing = compute_pacing(sub_sv)
@@ -308,12 +308,13 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
         )
 
         if hyp is not None:
+            verify_sv_logs_consistency(pub, hyp)
+
             hyp_sv = []
             hyp_stream_names = []
             with SvExtractor(hyp) as hyp_extractor:
                 hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams)
 
-            verify_sv_logs_consistency(pub, hyp)
             hyp_latencies, total_sv_drop = compute_latency(pub_sv, hyp_sv)
             hyp_pace = compute_pacing(hyp_sv)
             adoc_file.write(

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -89,39 +89,6 @@ class SvExtractor:
         return sv, stream_names
 
 
-def extract_sv(sv_file_path, streams):
-    stream_number = 0
-    with open(f"{sv_file_path}", "r", encoding="utf-8") as sv_file:
-        sv_content = sv_file.read().splitlines()
-
-    sv_id = np.array([str(item.split(":")[1]) for item in sv_content])
-    stream_names = np.unique(sv_id)
-
-    sv = [i for i in range(len(streams))]
-
-    sv_it = np.array([str(item.split(":")[0]) for item in sv_content])
-    sv_cnt = np.array([int(item.split(":")[2]) for item in sv_content])
-    sv_timestamps = np.array([int(item.split(":")[3]) for item in sv_content])
-
-    for stream in streams:
-        id_occurrences = np.where(sv_id == f"{stream:04x}")
-
-        sv_it_occurrences = sv_it[id_occurrences]
-        sv_cnt_occurrences = sv_cnt[id_occurrences]
-        sv_timestamps_occurrences = sv_timestamps[id_occurrences]
-
-        sv[stream_number] = [sv_it_occurrences, sv_cnt_occurrences, sv_timestamps_occurrences]
-
-        stream_number += 1
-
-    if stream_number == 0:
-        print(f"Fatal: no streams found in {sv_file_path}."
-              "Is the file empty or is the -S argument correct?")
-        exit(1)
-
-
-    return sv, stream_names
-
 def verify_sv_logs_consistency(sv_data_1, sv_data_2, sv_filename_1, sv_filename_2):
 # Verify that both sv files are comparables. It means:
 # - contains the same number of streams
@@ -286,8 +253,13 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
             """
         )
 
-        pub_sv, _ = extract_sv(pub, streams)
-        sub_sv, sub_stream_names = extract_sv(sub, streams)
+        pub_sv = []
+        sub_sv = []
+        sub_stream_names = []
+        with SvExtractor(pub) as pub_extractor, SvExtractor(sub) as sub_extractor:
+            pub_sv, _ = pub_extractor.extract_sv(streams)
+            sub_sv, sub_stream_names = sub_extractor.extract_sv(streams)
+
         verify_sv_logs_consistency(pub_sv, sub_sv, pub, sub)
 
         latencies, total_sv_drop = compute_latency(pub_sv, sub_sv)
@@ -314,7 +286,11 @@ def generate_adoc(pub, hyp, sub, streams, hyp_name, sub_name, output, max_latenc
         )
 
         if hyp is not None:
-            hyp_sv, hyp_stream_names = extract_sv(hyp, streams)
+            hyp_sv = []
+            hyp_stream_names = []
+            with SvExtractor(hyp) as hyp_extractor:
+                hyp_sv, hyp_stream_names = hyp_extractor.extract_sv(streams)
+
             verify_sv_logs_consistency(pub_sv, hyp_sv, pub, hyp)
             hyp_latencies, total_sv_drop = compute_latency(pub_sv, hyp_sv)
             hyp_pace = compute_pacing(hyp_sv)

--- a/sv_timestamp_analysis.py
+++ b/sv_timestamp_analysis.py
@@ -90,20 +90,12 @@ class SvExtractor:
 
 
 def verify_sv_logs_consistency(sv_data_1, sv_data_2, sv_filename_1, sv_filename_2):
-# Verify that both sv files are comparables. It means:
-# - contains the same number of streams
-# - contains the same number of iterations
+# Verify that both sv files are comparables. It means that they contain the same number of iterations.
 # If they do not have the same number of iterations, it can mean :
 # - packets reordering
 # - too many SV lost.
-# In both cases, the latency cannot be computed, because a received SV cannot
+# In that case, the latency cannot be computed, because a received SV cannot
 # be linked correctly to a published SV.
-
-    # Check for same number of streams
-    if len(sv_data_1) != len(sv_data_2):
-        raise ValueError(
-            f"{sv_filename_1} has {len(sv_data_1)} stream, but {sv_filename_2} has {len(sv_data_2)}'"
-        )
 
     # Check last iteration counter
     for stream in range(0, len(sv_data_1)):


### PR DESCRIPTION
Improve the sv-timestamp-analysis script to process large amounts of data.

This script's input data is an exhaustive list of timestamps of each IEC 61850 SV packets that were sent by a publisher are received by a subscriber machine during a SEAPATH latency test.
Because a single SV channel sends over 4000 SV packets per second and that data is saved as text, resulting data files can be quite large.
For example the file size for 15 mins of SV data with a single stream is roughly 106 Mb.
With tests of multiple hours (e.g. 5H, 8H, ...), data files would weight multiple Gigabytes.
Moreover, the amount of data is doubled for a SV latency test, as SVs are recorded on both publisher and subscriber sides.

Currently, when the sv-timestamp-analysis script processes these data files, it loads them once entirely in RAM, then process the data. This does not scale well with large volume of data from hours long SV latency tests.
Having a script loading multiple gigabytes of data in RAM isn't desirable.

This PR refactor in-depth the way SV data are read and processed.
* Instead of reading the full SV data (both publisher and subscriber), process by parts / chunks of the input data. That way the script only needs the current chunk of data to be loaded in RAM.
Chunk boundaries are defined by SV iteration boundaries, as sv drops can only be recovered in a given SV iteration.
* Refactor the way latencies and pacing results are stored.
Instead of keeping every data point in RAM (e.g. storing 10,000 integers for 150 µs latencies), keep only the total count each latency value happened. (e.g. storing that 150 µs latency happened 10,000, only needs 2 integers).
The former approach is indeed extremely inefficient for long latency tests. For example, with a 5H long test for a single SV stream, `5*60*60*4,000=72,000,000` SV will be sent and the same number of latencies will be computed.
Assuming values in microseconds are stored on 64 bits integers (the default for numpy arrays of integers), this would be equivalent to `(72,000,000*8) = 576,000,000 bytes ~= 549 Mb`, where most of the latencies are equals.
  * Use pandas DataFrame to easily store and increment latencies and pacing counts across chunks of data with a minimal memory footprint.
* Remove unneeded SV data validity check
* Check SV iteration consistency in SV data by reading the end of the files with `less`, instead of requiring the entire SV data.
* Make various improvements to code and docstring to improve maintainability of the script.

Note that part of this PR temporarily breaks the script while refactoring the processing logic, to allow incrementally adding changes to avoid large commits. But the PR in itself preserve all functionalities of the script.